### PR TITLE
Add User Pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -55,8 +55,9 @@
                 rounded
                 text
                 @click="
-                  if (userStore.isStudent)
-                    $router.push({ name: 'student-details' });
+                  userStore.isStudent ?
+                    $router.push({ name: 'student-details' }) :
+                    $router.push({ name: 'user-details' });
                 "
               >
                 My Details

--- a/src/components/StudentDetails.vue
+++ b/src/components/StudentDetails.vue
@@ -194,6 +194,7 @@
             this.selectedSong.title
           }}"?</v-card-title
         >
+        <!-- Delete/Cancel Actions -->
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn @click="deleteSong"> Delete </v-btn>
@@ -310,15 +311,23 @@ export default {
   },
   mounted() {
     // Get the instructor
-    let instructorPromise = userDS
-      .get(this.userStore.user.student.instructorId)
-      .then((res) => {
-        this.instructor = `${res.data.fName} ${res.data.lName}`;
-      })
-      .catch((e) => {
-        console.log(e);
-        this.instructor = "Error: not found";
-      });
+    let instructorPromise;
+    if (this.userStore.user.student.instructorId != null) {
+      instructorPromise = userDS
+        .get(this.userStore.user.student.instructorId)
+        .then((res) => {
+          this.instructor = `${res.data.fName} ${res.data.lName}`;
+        })
+        .catch((e) => {
+          console.log(e);
+          this.instructor = "Error: not found";
+        });
+    }
+    else {
+      // if no instructor is assigned, use an empty string and promise
+      this.instructor = "";
+      instructorPromise = Promise.resolve();
+    }
     // Get the student's songs
     let songsPromise = songDS
       .getAll()
@@ -368,15 +377,6 @@ export default {
           "Unable to display page because of 1 or more errors while loading data"
         );
       });
-
-    // if(this.prevRoute.name == 'student-edit') {
-    //     window.location.reload()
-    // }
-  },
-  // ,beforeRouteEnter(to, from, next) {
-  //     next(vm => {
-  //         vm.prevRoute = from;
-  //     })
-  // }
+  }
 };
 </script>

--- a/src/components/UserDetails.vue
+++ b/src/components/UserDetails.vue
@@ -1,0 +1,47 @@
+<template>
+    <div>
+        <v-container class="body-1">
+            <!-- Name -->
+            <v-row>
+                <v-col class="text-right py-0" cols="5">
+                    <strong>Name</strong>
+                </v-col>
+                <v-col class="py-0" cols="7">
+                    {{ userStore.name }}
+                </v-col>
+            </v-row>
+            <!-- Email -->
+            <v-row>
+                <v-col class="text-right py-0" cols="5">
+                    <strong>Email</strong>
+                </v-col>
+                <v-col class="py-0" cols="7">
+                    {{ userStore.user.email }}
+                </v-col>
+            </v-row>
+            <v-row><v-col></v-col></v-row>
+            <!-- Instruments -->
+            <v-row>
+                <v-col class="text-right py-0" cols="5">
+                    <strong>Instruments</strong>
+                </v-col>
+                <v-col class="py-0" cols="7">
+                    <div v-for="instrument in userStore.user.instruments" :key="instrument.id">
+                        {{ instrument.instrument }}
+                    </div>
+                </v-col>
+            </v-row>
+        </v-container>
+    </div>
+</template>
+<script>
+import { useUserStore } from '@/stores/userStore';
+import { mapStores } from 'pinia';
+
+export default {
+    name: 'user-details'
+    ,computed: {
+        ...mapStores(useUserStore)
+    }
+}
+</script>

--- a/src/components/UserEdit.vue
+++ b/src/components/UserEdit.vue
@@ -1,0 +1,191 @@
+<template>
+    <v-container class="body-1" v-if="loaded">
+        <!-- Name -->
+        <v-row>
+            <v-col class="text-right py-0" cols="4">
+                <strong>Name</strong>
+            </v-col>
+            <v-col class="py-0" cols="8">
+                {{ user.name }}
+            </v-col>
+        </v-row>
+        <!-- Email -->
+        <v-row>
+            <v-col class="text-right py-0" cols="4">
+                <strong>Email</strong>
+            </v-col>
+            <v-col class="py-0" cols="8">
+                {{ user.email }}
+            </v-col>
+        </v-row>
+        <v-row><v-col></v-col></v-row>
+        <!-- Roles -->
+        <v-row>
+            <v-col class="text-right py-0" align-self="center" cols="4">
+                <strong>Roles</strong>
+            </v-col>
+            <v-col class="py-0" cols="8">
+                <v-select
+                    v-model="user.roleIds"
+                    :items="allRoles"
+                    item-text="role"
+                    item-value="id"
+                    multiple
+                    dense
+                ></v-select>
+            </v-col>
+        </v-row>
+        <!-- Instruments -->
+        <v-row>
+            <v-col class="text-right py-0" align-self="center" cols="4">
+                <strong>Instruments</strong>
+            </v-col>
+            <v-col class="py-0" cols="8">
+                <v-select
+                    v-model="user.instrumentIds"
+                    :items="allInstruments"
+                    item-text="instrument"
+                    item-value="id"
+                    multiple
+                    dense
+                ></v-select>
+            </v-col>
+        </v-row>
+        <v-row class="mx-12">
+            <v-btn @click="Save">
+                Save Changes
+            </v-btn>
+        </v-row>
+    </v-container>
+</template>
+<script>
+import { useUserStore } from '@/stores/userStore';
+import { mapStores } from 'pinia';
+import userDS from '@/services/UserDataService';
+import roleDS from '@/services/RoleDataService';
+import instrumentDS from '@/services/InstrumentDataService';
+
+export default {
+    name: 'user-edit'
+    ,data() {
+        return {
+            user: {}
+            ,allInstruments: []
+            ,allRoles: []
+
+            ,loaded: false
+        };
+    }
+    ,computed: {
+        ...mapStores(useUserStore)
+    }
+    ,methods: {
+        Save() {
+            this.UpdateRoles();
+            this.UpdateInstruments();
+        },
+        async UpdateRoles() {
+            let promises = [];
+            // Remove roles that the user no longer does
+            let rolesToRemove = this.user.prevRoles.filter(i => !this.user.roleIds.includes(i));
+            for (const inst of rolesToRemove) {
+                promises.push(
+                    userDS.removeRole(this.user.id, inst)
+                        .then(() => {
+                            console.log(`${this.allRoles.find(i => i.id == inst).role} removed from ${this.user.name}`);
+                        })
+                );
+            }
+            // Add roles that the user now does
+            let rolesToAdd = this.user.roleIds.filter(i => !this.user.prevRoles.includes(i));
+            for (const inst of rolesToAdd) {
+                promises.push(
+                    userDS.addRole(this.user.id, inst)
+                       .then(() => {
+                           console.log(`${this.allRoles.find(i => i.id == inst).role} added to ${this.user.name}`);
+                       })
+                );
+            }
+            // Await backend requests
+            await Promise.all(promises)
+                .then(() => {
+                    console.log("All roles updated successfully");
+                })
+                .catch((err) => {
+                    console.log(err);
+                });
+            // Refresh the cached list of roles
+            this.user.prevRoles = this.user.roleIds;
+        },
+        async UpdateInstruments() {
+            let promises = [];
+            // Remove instruments that the user no longer plays
+            let instToRemove = this.user.prevInstruments.filter(i => !this.user.instrumentIds.includes(i));
+            for (const inst of instToRemove) {
+                promises.push(
+                    userDS.removeInstrument(this.user.id, inst)
+                        .then(() => {
+                            console.log(`${this.allInstruments.find(i => i.id == inst).instrument} removed from ${this.user.name}`);
+                        })
+                );
+            }
+            // Add instruments that the user now plays
+            let instToAdd = this.user.instrumentIds.filter(i => !this.user.prevInstruments.includes(i));
+            for (const inst of instToAdd) {
+                promises.push(
+                    userDS.addInstrument(this.user.id, inst)
+                        .then(() => {
+                            console.log(`${this.allInstruments.find(i => i.id == inst).instrument} added to ${this.user.name}`);
+                        })
+                );
+            }
+            // Await backend requests
+            await Promise.all(promises)
+                .then(() => {
+                    console.log("All instruments updated successfully");
+                })
+                .catch((err) => {
+                    console.log(err);
+                });
+            // Refresh the cached list of instruments
+            this.user.prevInstruments = this.user.instrumentIds;
+        }
+    }
+    ,async mounted() {
+        // Get the user's data
+        let userPromise = userDS.get(this.$route.params.id)
+            .then(res => {
+                this.user = {
+                    id: res.data.id
+                    ,name: `${res.data.fName} ${res.data.lName}`
+                    ,email: res.data.email
+                    ,roleIds: res.data.roles.map(r => r.id)
+                    ,instrumentIds: res.data.instruments.map(i => i.id)
+                };
+                this.user.prevRoles = this.user.roleIds;
+                this.user.prevInstruments = this.user.instrumentIds;
+                console.log(this.user);
+                console.log(res.data);
+            });
+        // Get all roles
+        let rolesPromise = roleDS.getAll()
+            .then(res => {
+                this.allRoles = res.data;
+            });
+        // Get all instruments
+        let instrumentsPromise = instrumentDS.getAll()
+            .then(res => {
+                this.allInstruments = res.data;
+            });
+        // Mark page as loaded when all data is loaded
+        await Promise.all([userPromise, rolesPromise, instrumentsPromise])
+            .then(() => {
+                this.loaded = true;
+            })
+            .catch((err) => {
+                console.log(err);
+            });
+        // Wait for data; then mark page as loaded
+    }
+}
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -49,5 +49,15 @@ export default new Router({
       ,name: "student-edit"
       ,component: () => import('./components/StudentEdit')
     },
+    {
+      path: "/user"
+      ,name: "user-details"
+      ,component: () => import('./components/UserDetails')
+    },
+    {
+      path: "/user/:id"
+      ,name: "user-edit"
+      ,component: () => import('./components/UserEdit')
+    }
   ],
 });

--- a/src/services/RoleDataService.js
+++ b/src/services/RoleDataService.js
@@ -1,0 +1,19 @@
+import http from '../http-common';
+class RoleDataService {
+  getAll() {
+    return http.get("/roles");
+  }
+  get(id) {
+    return http.get(`/roles/${id}`);
+  }
+  create(data) {
+    return http.post("/roles", data);
+  }
+  update(id, data) {
+    return http.put(`/roles/${id}`, data);
+  }
+  delete(id) {
+    return http.delete(`/roles/${id}`);
+  }
+}
+export default new RoleDataService();

--- a/src/services/UserDataService.js
+++ b/src/services/UserDataService.js
@@ -24,5 +24,11 @@ class UserDataService {
   removeInstrument(userId, instrumentId) {
     return http.delete(`/userInstruments?userId=${userId}&instrumentId=${instrumentId}`);
   }
+  addRole(userId, roleId) {
+    return http.post(`/userRole?userId=${userId}&roleId=${roleId}`);
+  }
+  removeRole(userId, roleId) {
+    return http.delete(`/userRole?userId=${userId}&roleId=${roleId}`);
+  }
 }
 export default new UserDataService();


### PR DESCRIPTION
Added user-details and user-edit pages
When a user goes to their details page, it will direct them to student-details if they're a student or user-details if they are not.
The user-edit page is able to edit a user's roles and instruments.
Added service functions for handling roles.
